### PR TITLE
Fix for vundle installation

### DIFF
--- a/manifests/installation.pp
+++ b/manifests/installation.pp
@@ -37,7 +37,7 @@ define vundle::installation (
   }
 
   exec { "vundle-update-${name}":
-    command     => "vim --not-a-term +PluginInstall +qall",
+    command     => "vim +PluginInstall +qall",
     user        => $name,
     cwd         => $path,
     path        => '/usr/bin/:/bin/',


### PR DESCRIPTION
Fixed "Error: /Stage[main]/Main/Vundle::Installation[root]/Exec[vundle-update-root]: Failed to call refresh: 'vim --not-a-term +PluginInstall +qall' returned 1 instead of one of [0]
Error: /Stage[main]/Main/Vundle::Installation[root]/Exec[vundle-update-root]: 'vim --not-a-term +PluginInstall +qall' returned 1 instead of one of [0]"